### PR TITLE
Draft of politicalCompetitive schema

### DIFF
--- a/endpoints/api.yaml
+++ b/endpoints/api.yaml
@@ -200,6 +200,7 @@ info:
     | Linear TV | A term used for real-time television services that are transmitted on a schedule. Most TV programs originate as linear TV but may become time-shifted for later viewing. |
     | Media Outlet | Station or network (seller) |
     | Piggyback | Back-to-back scheduling of two or more brand commercials of one advertiser in network or spot positions. |
+    | Political Competitive | Summaries of political buys made available by sellers to buyers to report on the national media environment. |
     | Preemption | A term used when a unit does not air as originally scheduled. |
     | Private Marketplace | Programmatic trading environment in which a publisher makes available a segment of inventory to an advertiser at a defined price. |
     | Programmatic TV (PTV): | An automated, technology- or data-driven method of buying linear TV |
@@ -267,6 +268,8 @@ paths:
     $ref: 'audiences.yaml#/paths/~1buyer~1audiences'
   /seller/audiences:
     $ref: 'audiences.yaml#/paths/~1seller~1audiences'
+  /seller/politicalCompetitives:
+    $ref: 'politicalCompetitive.yaml#/paths/~1seller~1politicalCompetitives'
 components:
   securitySchemes:
     bearerAuth:

--- a/endpoints/examples/SellerPoliticalCompetitiveNew.json
+++ b/endpoints/examples/SellerPoliticalCompetitiveNew.json
@@ -1,0 +1,44 @@
+{ 
+  "transactionHeader": { 
+    "tipVersion": "5.1.0", 
+    "transactionId": { 
+      "transactionId": "6A61B212-4DBD-431E-A953-8873561AF781", 
+      "transactionType": "New", 
+      "sourceId": "490", 
+      "sourceName": "WQRF-TV" 
+    }, 
+    "timeStamp": "2020-07-01T19:17:28Z" 
+  }, 
+  "politicalCompetitive": [ 
+    { 
+      "id" : "123456789", 
+      "flightStart" : "2020-07-08", 
+      "flightEnd" : "2020-07-15", 
+      "advertiser" : "an Advertiser", 
+      "agency" : "an Agency", 
+      "market" : "Chicago", 
+      "station" : "WQRF", 
+      "adSeconds" : 30, 
+      "totalDollars" : 2000.00, 
+      "state" : "IL", 
+      "repFirm" : "a Rep Firm", 
+      "bandCode" : "TV", 
+      "affiliate" : "An affiliate"
+    }, 
+    { 
+      "id" : "123456790", 
+      "flightStart" : "2020-07-15", 
+      "flightEnd" : "2020-07-22", 
+      "advertiser" : "another Advertiser", 
+      "agency" : "another Agency", 
+      "market" : "Chicago", 
+      "station" : "WQRF", 
+      "adSeconds" : 60, 
+      "totalDollars" : 2500.00, 
+      "state" : "IL", 
+      "repFirm" : "a Rep Firm", 
+      "bandCode" : "TV", 
+      "affiliate" : "An affiliate" 
+    } 
+  ] 
+} 

--- a/endpoints/schemas/politicalCompetitiveSchemas.yaml
+++ b/endpoints/schemas/politicalCompetitiveSchemas.yaml
@@ -1,0 +1,113 @@
+openapi: 3.0.0
+info:
+  version: 5.1.0
+  title: Political Competitive Schema
+  description: Political Competitive Schema
+  termsOfService: http://placeholderdomain.io/terms/
+  contact:
+    name: TIP Initiative
+    email: tipinitiative@frontrowadvisory.com
+    url: http://placeholderdomain.io
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+paths: {}
+components:
+  schemas:
+    SellerPoliticalCompetitives:
+      description: Political Competitive schema
+      properties:
+        transactionHeader:
+          $ref: 'commonSchemas.yaml#/components/schemas/TransactionHeader'
+        politicalCompetitive:
+          type: array
+          items:
+            $ref: '#/components/schemas/politicalCompetitive'
+      required:
+        - transactionHeader
+        - politicalCompetitive
+    politicalCompetitive:
+      description: Individual Buy Information
+      properties:
+        id:
+          description: Buy Id
+          type: string
+        flightStart:
+          description: Start Date of Buy Flight
+          type: date
+        flightEnd:
+          description: End Date of Buy Flight
+          type: date
+        advertiser:
+          description: Advertiser name
+          type: string
+        agency:
+          description: Name of agency purchasing the buy for advertiser
+          type: string
+        market:
+          description: Market in which the buy is airing
+          type: string
+        station:
+          description: Name of station buy is airing on
+          type: string
+        adSeconds:
+          description: Spot length in seconds
+          type: integer
+        totalDollars:
+          description: Total dollars for the spot length and scheduled week
+          type: decimal
+        state:
+          description: US state abbreviation
+          type: string
+        repFirm:
+          description: Distributor or station group
+          type: string
+        affiliate:
+          description: Affiliate name. Required for TV orders
+          type: string
+        bandCode:
+          description: TV or radio identifier
+          type: string
+          enum:
+            - tv
+            - fm
+            - am
+        cableBroadcastTag:
+          description: Cable or broadcast identifier
+          type: string
+          enum:
+            - cable
+            - broadcast
+            - radio
+            - satellite
+            - addressableCable
+        partyTag:
+          description: Party of the advertiser, ie, Republican or Democrat
+          type: string
+        issueCandidateTag:
+          description: Purpose; candidate or issue
+          type: string
+        electionTag:
+          description: Type and level of election
+          type: string
+        targetAudienceTag:
+          description: Audience or demographic targeted
+          type: string
+        raceTag:
+          description: Election race targeted
+          type: string
+        targetTag:
+          description: Political geo targeted
+          type: string
+      required:
+        - id
+        - flightStart
+        - flightEnd
+        - advertiser
+        - agency
+        - market
+        - station
+        - adSeconds
+        - totalDollars
+        - state
+        - repFirm


### PR DESCRIPTION
This represents the base object for political competitive, as mentioned here #150 . Required fields represent the summary of a buy (comparable to a logtime summary), optional fields generally are not provided by sellers but represent things that are sometimes included or are things buyers usually want to know (and will figure out themselves if need be.)

Happy to answer any questions/change anything as needed.